### PR TITLE
Patch 1 (modifications to cellxgene output | AMD links | scArches pretrained model links).

### DIFF
--- a/notebooks/cellxgene/00_get_metadata_from_integrated.ipynb
+++ b/notebooks/cellxgene/00_get_metadata_from_integrated.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### General modifications to cellxgene h5ad, to include dataset covariates\n",
+    "\n",
+    "This notebook uses >50 GB of RAM (cellxgene object). Please check resources before execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/rio/miniconda3/envs/mypy3/lib/python3.10/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.17.3 and <1.25.0 is required for this version of SciPy (detected version 1.26.1\n",
+      "  warnings.warn(f\"A NumPy version >={np_minversion} and <{np_maxversion}\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "import scanpy as sc\n",
+    "import pandas as pd\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this path should be replaced with the HRCA output\n",
+    "# h5ad_path = '' # '/mnt/f/workspace/theislab/retina/data/integrated_clean/snRNA.h5ad'\n",
+    "# !wget --nc https://www.dropbox.com/scl/fi/xsv7x2h9qkdxornnj3poo/snRNA_obs.tsv.gz\n",
+    "obs_snrna_path = 'snRNA_obs.tsv.gz'\n",
+    "assert os.path.exists(obs_snrna_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load snRNA h5ad from cellxgene. https://cellxgene.cziscience.com/collections/4c6eaf5c-6d57-4c76-b1e9-60df8c655f1e\n",
+    "cellxgene_path = '5173852a-0b77-4776-b1d2-5a4d924356b2.h5ad'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load metadata and cellxgene anndata\n",
+    "obs = pd.read_csv(obs_snrna_path)\n",
+    "ad = sc.read_h5ad(cellxgene_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a list of covariates is sequentially appended other covariates accordingly.\n",
+    "for k in ['donor', 'sampleid']: \n",
+    "    assert not k in ad.obs\n",
+    "    ad.obs[k] = ad.obs_names.map(obs[k].to_dict())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remember to save newly modified cellxgene for further experiments\n",
+    "# ad.write(...)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:mypy3]",
+   "language": "python",
+   "name": "conda-env-mypy3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/cellxgene/README.md
+++ b/notebooks/cellxgene/README.md
@@ -1,0 +1,8 @@
+## Cellxgene
+
+To include sample/dataset information into cellxgene.
+
+1. Download [this obs table](https://www.dropbox.com/scl/fi/xsv7x2h9qkdxornnj3poo/snRNA_obs.tsv.gz?rlkey=9o24zx1y44igg4ikiq9cavl3f&dl=0) used for snRNA-seq datasets during integration (wget link in notebook coming soon).
+2. Add relevant covariates from the the into the cellxgene object, using [this notebook](https://github.com/theislab/HRCA-reproducibility/tree/master/notebooks/cellxgene/00_gene_metadata_from_integrated.ipynb)).
+
+For usability and bug reports, please submit an [issue](https://github.com/theislab/HRCA-reproducibility/issues).

--- a/notebooks/query_to_reference/README.md
+++ b/notebooks/query_to_reference/README.md
@@ -1,0 +1,5 @@
+## Query to reference
+
+AMD datasets and pretrained models can be found here [Dropbox](https://www.dropbox.com/scl/fo/xw89wao5exb2mztb5q8qt/h?rlkey=cjdcqoxgj30el19fq9wy7qbak&dl=0)
+
+For usability and bug reports, please submit an [issue](https://github.com/theislab/HRCA-reproducibility/issues).


### PR DESCRIPTION
- Notebooks to add covariates in cellxgene h5ad, reusing metadata information benchmark. Newer versions of cellxgene are expected to include that information.
- Links to AMD and pre-trained models in query-to-reference README.